### PR TITLE
test: verify PR image upload flow

### DIFF
--- a/docs/dry-run-pr-upload.md
+++ b/docs/dry-run-pr-upload.md
@@ -1,0 +1,4 @@
+Dry-run PR for gh-attach PR upload verification.
+
+This PR exists only to validate image upload behavior against a pull request target.
+Please close without merging.


### PR DESCRIPTION
Dry-run PR to verify gh-attach can upload images to pull requests. Please close without merging.

Uploaded via `gh-attach` against a PR target:

![test-image.png](https://github.com/Addono/gh-attach/releases/download/_gh-attach-assets/test-image-15cg38.png)