### PR TITLE
fix: fall back to gh auth in MCP server

### DIFF
--- a/src/core/githubCliAuth.ts
+++ b/src/core/githubCliAuth.ts
@@ -1,0 +1,198 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+/**
+ * GitHub CLI account metadata exposed by `gh auth status --json hosts`.
+ */
+export interface GitHubCliAccount {
+  active: boolean;
+  host: string;
+  login: string;
+  state: string;
+  tokenSource?: string;
+  scopes?: string;
+  gitProtocol?: string;
+}
+
+/**
+ * Resolved GitHub CLI authentication state for a host.
+ */
+export interface GitHubCliAuthState {
+  accounts: GitHubCliAccount[];
+  token?: string;
+  login?: string;
+}
+
+interface ResolveGitHubCliAuthOptions {
+  hostname?: string;
+  owner?: string;
+  repo?: string;
+  execFileImpl?: typeof execFile;
+  fetchImpl?: typeof fetch;
+}
+
+function isGitHubCliAccount(value: unknown): value is GitHubCliAccount {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate["active"] === "boolean" &&
+    typeof candidate["host"] === "string" &&
+    typeof candidate["login"] === "string" &&
+    typeof candidate["state"] === "string"
+  );
+}
+
+function getApiBaseUrl(hostname: string): string {
+  return hostname === "github.com"
+    ? "https://api.github.com"
+    : `https://${hostname}/api/v3`;
+}
+
+function prioritizeAccounts(
+  accounts: GitHubCliAccount[],
+  owner?: string,
+): GitHubCliAccount[] {
+  const successful = accounts.filter((account) => account.state === "success");
+  const ownerLower = owner?.toLowerCase();
+
+  const ownerMatches = successful.filter(
+    (account) => account.login.toLowerCase() === ownerLower,
+  );
+  const active = successful.filter(
+    (account) =>
+      account.active &&
+      !ownerMatches.some((match) => match.login === account.login),
+  );
+  const rest = successful.filter(
+    (account) =>
+      !ownerMatches.some((match) => match.login === account.login) &&
+      !active.some((match) => match.login === account.login),
+  );
+
+  return [...ownerMatches, ...active, ...rest];
+}
+
+async function getGitHubCliTokenForUser(
+  hostname: string,
+  user: string,
+  execFileImpl: typeof execFile,
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileImpl("gh", [
+      "auth",
+      "token",
+      "--hostname",
+      hostname,
+      "--user",
+      user,
+    ]);
+    const token = stdout.trim();
+    return token.length > 0 ? token : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function tokenCanAccessRepository(
+  token: string,
+  hostname: string,
+  owner: string,
+  repo: string,
+  fetchImpl: typeof fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchImpl(
+      `${getApiBaseUrl(hostname)}/repos/${owner}/${repo}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lists accounts known to the GitHub CLI for a host.
+ */
+export async function listGitHubCliAccounts(
+  hostname = "github.com",
+  execFileImpl: typeof execFile = execFile,
+): Promise<GitHubCliAccount[]> {
+  try {
+    const { stdout } = await execFileImpl("gh", [
+      "auth",
+      "status",
+      "--hostname",
+      hostname,
+      "--json",
+      "hosts",
+    ]);
+
+    const parsed = JSON.parse(stdout) as {
+      hosts?: Record<string, unknown>;
+    };
+    const hostEntries = parsed.hosts?.[hostname];
+    if (!Array.isArray(hostEntries)) {
+      return [];
+    }
+
+    return hostEntries.filter(isGitHubCliAccount);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolves a usable GitHub token from `gh auth`, preferring the account most likely
+ * to have access to the requested repository.
+ */
+export async function resolveGitHubCliAuth(
+  options: ResolveGitHubCliAuthOptions = {},
+): Promise<GitHubCliAuthState> {
+  const hostname = options.hostname ?? "github.com";
+  const execFileImpl = options.execFileImpl ?? execFile;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const accounts = await listGitHubCliAccounts(hostname, execFileImpl);
+
+  for (const account of prioritizeAccounts(accounts, options.owner)) {
+    const token = await getGitHubCliTokenForUser(
+      hostname,
+      account.login,
+      execFileImpl,
+    );
+    if (!token) {
+      continue;
+    }
+
+    if (options.owner && options.repo) {
+      const accessible = await tokenCanAccessRepository(
+        token,
+        hostname,
+        options.owner,
+        options.repo,
+        fetchImpl,
+      );
+      if (!accessible) {
+        continue;
+      }
+    }
+
+    return {
+      accounts,
+      token,
+      login: account.login,
+    };
+  }
+
+  return { accounts };
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -24,7 +24,15 @@ import {
   createCookieExtractionStrategy,
   createRepoBranchStrategy,
 } from "../core/strategies/index.js";
-import { getSessionCookies, loadSession } from "../core/session.js";
+import {
+  getSessionCookies,
+  getSessionToken,
+  loadSession,
+} from "../core/session.js";
+import {
+  resolveGitHubCliAuth,
+  type GitHubCliAccount,
+} from "../core/githubCliAuth.js";
 import { parseTarget } from "../core/target.js";
 import { validateFile } from "../core/validation.js";
 import { upload } from "../core/upload.js";
@@ -32,6 +40,7 @@ import {
   AuthenticationError,
   UploadError,
   type UploadStrategy,
+  type UploadTarget,
 } from "../core/types.js";
 
 // Get package version
@@ -49,7 +58,7 @@ function getPackageVersion(): string {
 
 const VERSION = getPackageVersion();
 const AUTH_GUIDANCE =
-  "No authentication available. Set GITHUB_TOKEN (or GH_TOKEN), GH_ATTACH_COOKIES, or run 'gh-attach login' to save a browser session.";
+  "No authentication available. Set GITHUB_TOKEN (or GH_TOKEN), run 'gh-attach login' to save a session token, provide GH_ATTACH_COOKIES, or authenticate with the GitHub CLI. If multiple gh accounts are signed in, use 'gh auth status' to inspect them and 'gh auth token --user <login>' to verify the right identity.";
 
 /**
  * Token obtained via MCP elicitation — persists for the lifetime of the server process.
@@ -58,21 +67,96 @@ const AUTH_GUIDANCE =
  */
 let elicitedToken: string | null = null;
 
-/**
- * Returns the effective GitHub API token from all sources:
- * environment variables → MCP-elicited token.
- */
-function getEffectiveToken(): string | undefined {
-  return (
-    process.env.GITHUB_TOKEN ||
-    process.env.GH_TOKEN ||
-    elicitedToken ||
-    undefined
-  );
+interface EffectiveAuthState {
+  token?: string;
+  tokenSource?: "env" | "elicited" | "session" | "gh-cli";
+  tokenUser?: string;
+  cookies: string | null;
+  cliAccounts: GitHubCliAccount[];
 }
 
-function getEffectiveCookies(): string | null {
-  return process.env.GH_ATTACH_COOKIES ?? getSessionCookies(loadSession());
+/**
+ * Returns the effective GitHub API token from all sources:
+ * environment variables → elicited token → saved session token → gh auth fallback.
+ */
+async function getEffectiveAuth(
+  target?: UploadTarget,
+): Promise<EffectiveAuthState> {
+  const session = loadSession();
+  const cookies = process.env.GH_ATTACH_COOKIES ?? getSessionCookies(session);
+
+  if (process.env.GITHUB_TOKEN) {
+    return {
+      token: process.env.GITHUB_TOKEN,
+      tokenSource: "env",
+      cookies,
+      cliAccounts: [],
+    };
+  }
+
+  if (process.env.GH_TOKEN) {
+    return {
+      token: process.env.GH_TOKEN,
+      tokenSource: "env",
+      cookies,
+      cliAccounts: [],
+    };
+  }
+
+  if (elicitedToken) {
+    return {
+      token: elicitedToken,
+      tokenSource: "elicited",
+      cookies,
+      cliAccounts: [],
+    };
+  }
+
+  let ghCliAuth: Awaited<ReturnType<typeof resolveGitHubCliAuth>> | undefined =
+    undefined;
+
+  if (target) {
+    ghCliAuth = await resolveGitHubCliAuth({
+      owner: target.owner,
+      repo: target.repo,
+    });
+
+    if (ghCliAuth.token) {
+      return {
+        token: ghCliAuth.token,
+        tokenSource: "gh-cli",
+        tokenUser: ghCliAuth.login,
+        cookies,
+        cliAccounts: ghCliAuth.accounts,
+      };
+    }
+  }
+
+  const sessionToken = getSessionToken(session);
+  if (sessionToken) {
+    return {
+      token: sessionToken,
+      tokenSource: "session",
+      tokenUser: session?.username,
+      cookies,
+      cliAccounts: [],
+    };
+  }
+
+  if (!ghCliAuth) {
+    ghCliAuth = await resolveGitHubCliAuth({
+      owner: target?.owner,
+      repo: target?.repo,
+    });
+  }
+
+  return {
+    token: ghCliAuth.token,
+    tokenSource: ghCliAuth.token ? "gh-cli" : undefined,
+    tokenUser: ghCliAuth.login,
+    cookies,
+    cliAccounts: ghCliAuth.accounts,
+  };
 }
 
 type TokenElicitationResult = "accepted" | "cancelled" | "unavailable";
@@ -125,7 +209,10 @@ async function maybeElicitToken(
   return "unavailable";
 }
 
-function shouldAttemptTokenElicitation(preferredStrategy?: string): boolean {
+function shouldAttemptTokenElicitation(
+  preferredStrategy: string | undefined,
+  auth: EffectiveAuthState,
+): boolean {
   const canUseTokenStrategy =
     preferredStrategy === undefined ||
     preferredStrategy === "release-asset" ||
@@ -135,15 +222,18 @@ function shouldAttemptTokenElicitation(preferredStrategy?: string): boolean {
     return false;
   }
 
-  if (getEffectiveToken() || getEffectiveCookies()) {
+  if (auth.token || auth.cookies) {
     return false;
   }
 
   return true;
 }
 
-function shouldRetryWithElicitedToken(preferredStrategy?: string): boolean {
-  if (getEffectiveToken()) {
+function shouldRetryWithElicitedToken(
+  preferredStrategy: string | undefined,
+  auth: EffectiveAuthState,
+): boolean {
+  if (auth.token) {
     return false;
   }
 
@@ -601,19 +691,22 @@ async function handleUploadImage(
       };
     }
 
-    if (shouldAttemptTokenElicitation(args.strategy)) {
-      attemptedTokenElicitation = true;
-      await maybeElicitToken(server);
-    }
-
     // Parse target
     const target = parseTarget(args.target);
 
     // Validate file
     await validateFile(uploadPath);
 
+    let auth = await getEffectiveAuth(target);
+
+    if (shouldAttemptTokenElicitation(args.strategy, auth)) {
+      attemptedTokenElicitation = true;
+      await maybeElicitToken(server);
+      auth = await getEffectiveAuth(target);
+    }
+
     // Build strategies list
-    const strategies = getStrategies(args.strategy);
+    const strategies = getStrategies(args.strategy, auth);
 
     if (strategies.length === 0) {
       return {
@@ -633,7 +726,7 @@ async function handleUploadImage(
     } catch (error) {
       const canRetryWithToken =
         !attemptedTokenElicitation &&
-        shouldRetryWithElicitedToken(args.strategy) &&
+        shouldRetryWithElicitedToken(args.strategy, auth) &&
         (error instanceof AuthenticationError || error instanceof UploadError);
 
       if (!canRetryWithToken) {
@@ -646,7 +739,8 @@ async function handleUploadImage(
         throw error;
       }
 
-      const retryStrategies = getStrategies(args.strategy);
+      auth = await getEffectiveAuth(target);
+      const retryStrategies = getStrategies(args.strategy, auth);
       if (retryStrategies.length === 0) {
         throw error;
       }
@@ -703,11 +797,18 @@ async function handleLogin(
   server: Server,
 ): Promise<{ content: TextContent[] }> {
   // Short-circuit: already authenticated via environment or prior elicitation
-  const existingToken = getEffectiveToken();
-  const existingCookies = getEffectiveCookies();
+  const auth = await getEffectiveAuth();
+  const existingToken = auth.token;
+  const existingCookies = auth.cookies;
 
   if (existingToken || existingCookies) {
-    const via = existingToken ? "token" : "browser session";
+    const via = existingToken
+      ? auth.tokenSource === "gh-cli" && auth.tokenUser
+        ? `GitHub CLI token (${auth.tokenUser})`
+        : auth.tokenSource === "session" && auth.tokenUser
+          ? `saved session token (${auth.tokenUser})`
+          : "token"
+      : "browser session";
     return {
       content: [
         {
@@ -735,7 +836,7 @@ async function handleLogin(
       content: [
         {
           type: "text",
-          text: "Authentication cancelled. Set the GITHUB_TOKEN environment variable or run 'gh-attach login' to authenticate.",
+          text: "Authentication cancelled. Set GITHUB_TOKEN, run 'gh-attach login', or rely on GitHub CLI auth (`gh auth status`, `gh auth token --user <login>`).",
         },
       ],
     };
@@ -746,7 +847,7 @@ async function handleLogin(
     content: [
       {
         type: "text",
-        text: `To authenticate, set the GITHUB_TOKEN environment variable with a GitHub personal access token, or run 'gh-attach login' to save a browser session.\n\nCreate a token at: https://github.com/settings/tokens`,
+        text: `To authenticate, set the GITHUB_TOKEN environment variable with a GitHub personal access token, run 'gh-attach login' to save a session token, or rely on GitHub CLI auth.\n\nUse 'gh auth status' to inspect signed-in identities and 'gh auth token --user <login>' to verify which account can access the target repository.\n\nCreate a token at: https://github.com/settings/tokens`,
       },
     ],
   };
@@ -756,25 +857,41 @@ async function handleLogin(
  * Handles the check_auth tool call.
  */
 async function handleCheckAuth(): Promise<{ content: TextContent[] }> {
-  const token = getEffectiveToken();
-  const cookies = getEffectiveCookies();
+  const auth = await getEffectiveAuth();
 
   const strategies: string[] = [];
-  if (token) {
+  if (auth.token) {
     strategies.push("release-asset", "repo-branch");
   }
-  if (cookies) {
+  if (auth.cookies) {
     strategies.push("browser-session");
   }
   strategies.push("cookie-extraction");
 
-  const authenticated = token !== undefined || cookies !== null;
+  const authenticated = auth.token !== undefined || auth.cookies !== null;
 
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify({ authenticated, strategies }, null, 2),
+        text: JSON.stringify(
+          {
+            authenticated,
+            strategies,
+            tokenSource: auth.tokenSource,
+            tokenUser: auth.tokenUser,
+            accounts: auth.cliAccounts.map(
+              ({ login, active, state, scopes }) => ({
+                login,
+                active,
+                state,
+                scopes,
+              }),
+            ),
+          },
+          null,
+          2,
+        ),
       },
     ],
   };
@@ -790,17 +907,17 @@ async function handleListStrategies(): Promise<{ content: TextContent[] }> {
     description: string;
   }> = [];
 
-  const token = getEffectiveToken();
-  const cookies = getEffectiveCookies();
+  const auth = await getEffectiveAuth();
 
   strategies.push({
     name: "release-asset",
-    available: !!token,
-    description: "Upload as GitHub release asset (requires GITHUB_TOKEN)",
+    available: !!auth.token,
+    description:
+      "Upload as GitHub release asset (requires a GitHub token from env, saved session, or gh auth)",
   });
   strategies.push({
     name: "browser-session",
-    available: !!cookies,
+    available: !!auth.cookies,
     description:
       "Upload via saved browser session (requires GH_ATTACH_COOKIES or saved session state)",
   });
@@ -811,8 +928,9 @@ async function handleListStrategies(): Promise<{ content: TextContent[] }> {
   });
   strategies.push({
     name: "repo-branch",
-    available: !!token,
-    description: "Upload to repository branch (requires GITHUB_TOKEN)",
+    available: !!auth.token,
+    description:
+      "Upload to repository branch (requires a GitHub token from env, saved session, or gh auth)",
   });
 
   return {
@@ -828,33 +946,38 @@ async function handleListStrategies(): Promise<{ content: TextContent[] }> {
 /**
  * Gets the list of available strategies.
  */
-function getStrategies(preferredStrategy?: string): UploadStrategy[] {
+function getStrategies(
+  preferredStrategy: string | undefined,
+  auth: EffectiveAuthState,
+): UploadStrategy[] {
   const strategies: UploadStrategy[] = [];
-  const token = getEffectiveToken();
-  const cookies = getEffectiveCookies();
 
   if (preferredStrategy) {
     switch (preferredStrategy) {
       case "release-asset":
-        if (token) strategies.push(createReleaseAssetStrategy(token));
+        if (auth.token) strategies.push(createReleaseAssetStrategy(auth.token));
         break;
       case "browser-session":
-        if (cookies) strategies.push(createBrowserSessionStrategy(cookies));
+        if (auth.cookies) {
+          strategies.push(createBrowserSessionStrategy(auth.cookies));
+        }
         break;
       case "cookie-extraction":
         strategies.push(createCookieExtractionStrategy());
         break;
       case "repo-branch":
-        if (token) strategies.push(createRepoBranchStrategy(token));
+        if (auth.token) strategies.push(createRepoBranchStrategy(auth.token));
         break;
     }
   } else {
     // Default order
-    if (cookies) strategies.push(createBrowserSessionStrategy(cookies));
+    if (auth.cookies) {
+      strategies.push(createBrowserSessionStrategy(auth.cookies));
+    }
     strategies.push(createCookieExtractionStrategy());
-    if (token) {
-      strategies.push(createReleaseAssetStrategy(token));
-      strategies.push(createRepoBranchStrategy(token));
+    if (auth.token) {
+      strategies.push(createReleaseAssetStrategy(auth.token));
+      strategies.push(createRepoBranchStrategy(auth.token));
     }
   }
 

--- a/test/unit/core/githubCliAuth.test.ts
+++ b/test/unit/core/githubCliAuth.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  listGitHubCliAccounts,
+  resolveGitHubCliAuth,
+} from "../../../src/core/githubCliAuth.js";
+
+type ExecResult = {
+  stdout: string;
+  stderr?: string;
+};
+
+describe("githubCliAuth", () => {
+  it("lists accounts from gh auth status JSON", async () => {
+    const execFileImpl = vi
+      .fn<(...args: unknown[]) => Promise<ExecResult>>()
+      .mockResolvedValue({
+        stdout: JSON.stringify({
+          hosts: {
+            "github.com": [
+              {
+                active: true,
+                host: "github.com",
+                login: "AKnapen-Ahold",
+                state: "success",
+              },
+              {
+                active: false,
+                host: "github.com",
+                login: "Addono",
+                state: "success",
+              },
+            ],
+          },
+        }),
+      });
+
+    const accounts = await listGitHubCliAccounts("github.com", execFileImpl);
+
+    expect(accounts.map((account) => account.login)).toEqual([
+      "AKnapen-Ahold",
+      "Addono",
+    ]);
+  });
+
+  it("prefers the active gh account when no target repository is provided", async () => {
+    const execFileImpl = vi
+      .fn<(...args: unknown[]) => Promise<ExecResult>>()
+      .mockImplementation(async (_file, args) => {
+        const commandArgs = Array.isArray(args) ? args : [];
+        if (commandArgs[1] === "status") {
+          return {
+            stdout: JSON.stringify({
+              hosts: {
+                "github.com": [
+                  {
+                    active: true,
+                    host: "github.com",
+                    login: "AKnapen-Ahold",
+                    state: "success",
+                  },
+                  {
+                    active: false,
+                    host: "github.com",
+                    login: "Addono",
+                    state: "success",
+                  },
+                ],
+              },
+            }),
+          };
+        }
+
+        if (commandArgs[1] === "token") {
+          return { stdout: "ghs_active_token\n" };
+        }
+
+        throw new Error(`Unexpected gh call: ${commandArgs.join(" ")}`);
+      });
+
+    const auth = await resolveGitHubCliAuth({
+      execFileImpl,
+      fetchImpl: vi.fn(),
+    });
+
+    expect(auth.token).toBe("ghs_active_token");
+    expect(auth.login).toBe("AKnapen-Ahold");
+  });
+
+  it("falls back to the account that can access the target repository", async () => {
+    const execFileImpl = vi
+      .fn<(...args: unknown[]) => Promise<ExecResult>>()
+      .mockImplementation(async (_file, args) => {
+        const commandArgs = Array.isArray(args) ? args : [];
+        if (commandArgs[1] === "status") {
+          return {
+            stdout: JSON.stringify({
+              hosts: {
+                "github.com": [
+                  {
+                    active: true,
+                    host: "github.com",
+                    login: "AKnapen-Ahold",
+                    state: "success",
+                  },
+                  {
+                    active: false,
+                    host: "github.com",
+                    login: "Addono",
+                    state: "success",
+                  },
+                ],
+              },
+            }),
+          };
+        }
+
+        if (commandArgs[1] === "token" && commandArgs[5] === "AKnapen-Ahold") {
+          return { stdout: "ghs_wrong_identity\n" };
+        }
+
+        if (commandArgs[1] === "token" && commandArgs[5] === "Addono") {
+          return { stdout: "ghs_addono_identity\n" };
+        }
+
+        throw new Error(`Unexpected gh call: ${commandArgs.join(" ")}`);
+      });
+
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        const authHeader =
+          typeof init?.headers === "object" &&
+          init.headers !== null &&
+          "Authorization" in init.headers
+            ? String(init.headers["Authorization"])
+            : undefined;
+        const ok =
+          url.endsWith("/repos/Addono/gh-attach") &&
+          authHeader === "Bearer ghs_addono_identity";
+        return new Response(JSON.stringify({ ok }), { status: ok ? 200 : 404 });
+      });
+
+    const auth = await resolveGitHubCliAuth({
+      owner: "Addono",
+      repo: "gh-attach",
+      execFileImpl,
+      fetchImpl,
+    });
+
+    expect(auth.token).toBe("ghs_addono_identity");
+    expect(auth.login).toBe("Addono");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns accounts without a token when no gh identity can access the target repo", async () => {
+    const execFileImpl = vi
+      .fn<(...args: unknown[]) => Promise<ExecResult>>()
+      .mockImplementation(async (_file, args) => {
+        const commandArgs = Array.isArray(args) ? args : [];
+        if (commandArgs[1] === "status") {
+          return {
+            stdout: JSON.stringify({
+              hosts: {
+                "github.com": [
+                  {
+                    active: true,
+                    host: "github.com",
+                    login: "AKnapen-Ahold",
+                    state: "success",
+                  },
+                ],
+              },
+            }),
+          };
+        }
+
+        if (commandArgs[1] === "token") {
+          return { stdout: "ghs_wrong_identity\n" };
+        }
+
+        throw new Error(`Unexpected gh call: ${commandArgs.join(" ")}`);
+      });
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", {
+        status: 404,
+      }),
+    );
+
+    const auth = await resolveGitHubCliAuth({
+      owner: "Addono",
+      repo: "gh-attach",
+      execFileImpl,
+      fetchImpl,
+    });
+
+    expect(auth.token).toBeUndefined();
+    expect(auth.login).toBeUndefined();
+    expect(auth.accounts.map((account) => account.login)).toEqual([
+      "AKnapen-Ahold",
+    ]);
+  });
+});

--- a/test/unit/mcp/handlers.test.ts
+++ b/test/unit/mcp/handlers.test.ts
@@ -76,6 +76,7 @@ const hoisted = vi.hoisted(() => ({
   mockParseTarget: vi.fn(),
   mockValidateFile: vi.fn(),
   mockUpload: vi.fn(),
+  mockResolveGitHubCliAuth: vi.fn(),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/server/index.js", () => {
@@ -118,6 +119,10 @@ vi.mock("../../../src/core/validation.js", () => ({
 
 vi.mock("../../../src/core/upload.js", () => ({
   upload: hoisted.mockUpload,
+}));
+
+vi.mock("../../../src/core/githubCliAuth.js", () => ({
+  resolveGitHubCliAuth: hoisted.mockResolveGitHubCliAuth,
 }));
 
 import { createMCPServer, mcpInternals } from "../../../src/mcp/index.js";
@@ -177,6 +182,7 @@ describe("MCP server handlers", () => {
     hoisted.mockParseTarget.mockReturnValue(hoisted.mockTarget);
     hoisted.mockValidateFile.mockResolvedValue(undefined);
     hoisted.mockUpload.mockResolvedValue(hoisted.mockUploadResult);
+    hoisted.mockResolveGitHubCliAuth.mockResolvedValue({ accounts: [] });
   });
 
   afterEach(() => {
@@ -269,6 +275,92 @@ describe("MCP server handlers", () => {
 
     expect(body.authenticated).toBe(true);
     expect(body.strategies).toEqual(["browser-session", "cookie-extraction"]);
+  });
+
+  it("reports authenticated status from saved session token", async () => {
+    saveSession({
+      token: "ghs_saved_session",
+      username: "saved-user",
+      expires: Date.now() + 86400000,
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({
+      params: { name: "check_auth", arguments: {} },
+    });
+
+    const body = JSON.parse(response.content[0]?.text ?? "{}") as {
+      authenticated: boolean;
+      strategies: string[];
+      tokenSource?: string;
+      tokenUser?: string;
+    };
+
+    expect(body.authenticated).toBe(true);
+    expect(body.strategies).toEqual([
+      "release-asset",
+      "repo-branch",
+      "cookie-extraction",
+    ]);
+    expect(body.tokenSource).toBe("session");
+    expect(body.tokenUser).toBe("saved-user");
+  });
+
+  it("reports authenticated status from gh auth fallback", async () => {
+    hoisted.mockResolveGitHubCliAuth.mockResolvedValue({
+      token: "ghs_from_gh_cli",
+      login: "Addono",
+      accounts: [
+        {
+          login: "AKnapen-Ahold",
+          active: true,
+          state: "success",
+          scopes: "repo, workflow",
+        },
+        {
+          login: "Addono",
+          active: false,
+          state: "success",
+          scopes: "repo, workflow",
+        },
+      ],
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({
+      params: { name: "check_auth", arguments: {} },
+    });
+
+    const body = JSON.parse(response.content[0]?.text ?? "{}") as {
+      authenticated: boolean;
+      strategies: string[];
+      tokenSource?: string;
+      tokenUser?: string;
+      accounts?: Array<{ login: string; active: boolean; state: string }>;
+    };
+
+    expect(body.authenticated).toBe(true);
+    expect(body.strategies).toEqual([
+      "release-asset",
+      "repo-branch",
+      "cookie-extraction",
+    ]);
+    expect(body.tokenSource).toBe("gh-cli");
+    expect(body.tokenUser).toBe("Addono");
+    expect(body.accounts).toEqual([
+      {
+        login: "AKnapen-Ahold",
+        active: true,
+        state: "success",
+        scopes: "repo, workflow",
+      },
+      {
+        login: "Addono",
+        active: false,
+        state: "success",
+        scopes: "repo, workflow",
+      },
+    ]);
   });
 
   it("lists strategy availability based on auth signals", async () => {
@@ -604,6 +696,110 @@ describe("MCP server handlers", () => {
     expect(passedStrategies.map((s) => s.name)).toEqual(["repo-branch"]);
   });
 
+  it("uses saved session token for token-backed strategies", async () => {
+    saveSession({
+      token: "ghs_saved_session",
+      username: "saved-user",
+      expires: Date.now() + 86400000,
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({
+      params: {
+        name: "upload_image",
+        arguments: {
+          filePath: "/tmp/example.png",
+          target: "octo/repo#42",
+          strategy: "release-asset",
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(hoisted.mockCreateReleaseAssetStrategy).toHaveBeenCalledWith(
+      "ghs_saved_session",
+    );
+  });
+
+  it("uses gh auth fallback token for token-backed strategies", async () => {
+    hoisted.mockResolveGitHubCliAuth.mockResolvedValue({
+      token: "ghs_from_gh_cli",
+      login: "Addono",
+      accounts: [
+        {
+          login: "AKnapen-Ahold",
+          active: true,
+          state: "success",
+        },
+        {
+          login: "Addono",
+          active: false,
+          state: "success",
+        },
+      ],
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({
+      params: {
+        name: "upload_image",
+        arguments: {
+          filePath: "/tmp/example.png",
+          target: "octo/repo#42",
+          strategy: "release-asset",
+          format: "url",
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(hoisted.mockCreateReleaseAssetStrategy).toHaveBeenCalledWith(
+      "ghs_from_gh_cli",
+    );
+  });
+
+  it("prefers target-aware gh auth over a saved session token during upload", async () => {
+    saveSession({
+      token: "ghs_saved_session",
+      username: "AKnapen-Ahold",
+      expires: Date.now() + 86400000,
+    });
+    hoisted.mockResolveGitHubCliAuth.mockResolvedValue({
+      token: "ghs_addono_token",
+      login: "Addono",
+      accounts: [
+        {
+          login: "AKnapen-Ahold",
+          active: true,
+          state: "success",
+        },
+        {
+          login: "Addono",
+          active: false,
+          state: "success",
+        },
+      ],
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({
+      params: {
+        name: "upload_image",
+        arguments: {
+          filePath: "/tmp/example.png",
+          target: "Addono/gh-attach#16",
+          strategy: "release-asset",
+          format: "url",
+        },
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(hoisted.mockCreateReleaseAssetStrategy).toHaveBeenCalledWith(
+      "ghs_addono_token",
+    );
+  });
+
   it("uses browser-session strategy when explicitly selected with cookies", async () => {
     process.env.GH_ATTACH_COOKIES = "user_session=abc123; logged_in=yes";
 
@@ -684,6 +880,26 @@ describe("MCP server handlers", () => {
 
     expect(response.isError).toBeUndefined();
     expect(response.content[0]?.text).toContain("Already authenticated");
+  });
+
+  it("login tool reports already-authenticated when gh auth fallback is available", async () => {
+    hoisted.mockResolveGitHubCliAuth.mockResolvedValue({
+      token: "ghs_from_gh_cli",
+      login: "Addono",
+      accounts: [
+        {
+          login: "Addono",
+          active: true,
+          state: "success",
+        },
+      ],
+    });
+
+    const { call } = await startServerAndGetHandlers();
+    const response = await call({ params: { name: "login", arguments: {} } });
+
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0]?.text).toContain("GitHub CLI token (Addono)");
   });
 
   it("login tool uses elicitation when client supports it and user accepts", async () => {


### PR DESCRIPTION
## Summary
- fall back to GitHub CLI auth in the MCP server when env tokens are not present
- prefer target-aware `gh auth token --user` selection for uploads so the correct identity is used
- recognize saved session tokens from `gh-attach login` and add test coverage for the new auth paths

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm test
- npm run build
- manual stdio MCP test with env tokens removed and a fresh server process