### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -87,8 +88,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+      - run: npm install -g npm@^11.5.1
       - run: npm ci
       - uses: actions/download-artifact@v7
         with:
@@ -121,8 +123,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+      - run: npm install -g npm@^11.5.1
       - run: npm ci
       - uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
   packages: write
+  id-token: write
 
 jobs:
   next-version:
@@ -21,9 +23,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
-          registry-url: https://npm.pkg.github.com
+      - run: npm install -g npm@^11.5.1
       - run: npm ci
       - id: resolve
         run: |
@@ -32,8 +34,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-binaries:
     name: Build ${{ matrix.asset_name }}
@@ -59,8 +60,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+      - run: npm install -g npm@^11.5.1
       - run: npm ci
       - run: npm run build
         env:
@@ -121,7 +123,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
       - run: npm ci
       - uses: actions/download-artifact@v7
         with:
@@ -140,5 +141,4 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.release/
 
 # Gatsby files
 .cache/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,7 +12,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "GH_ATTACH_BUILD_VERSION=${nextRelease.version} npm run build"
+        "prepareCmd": "GH_ATTACH_BUILD_VERSION=${nextRelease.version} npm run build && GH_ATTACH_RELEASE_VERSION=${nextRelease.version} npm run prepare:github-package",
+        "publishCmd": "npm run publish:github-package"
       }
     ],
     "@semantic-release/npm",

--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ GitHub doesn't provide an official API for attaching images to issues and pull r
 ### Standalone CLI (npm)
 
 ```bash
-# Install globally from GitHub Packages
-npm install -g @addono/gh-attach --registry=https://npm.pkg.github.com
+# Install globally from public npm
+npm install -g gh-attach
 ```
 
 Run it as `gh-attach ...`.
+
+### GitHub Packages mirror
+
+```bash
+# Install the scoped mirror from GitHub Packages
+npm install -g @addono/gh-attach --registry=https://npm.pkg.github.com
+```
 
 ### GitHub CLI extension
 
@@ -53,17 +60,17 @@ Run it as `gh-attach ...`.
 
 ```bash
 # Upload an image
-npx --registry=https://npm.pkg.github.com @addono/gh-attach upload ./screenshot.png --target owner/repo#42
+npx gh-attach upload ./screenshot.png --target owner/repo#42
 
 # Start the MCP server
-npx --registry=https://npm.pkg.github.com @addono/gh-attach mcp --transport stdio
+npx gh-attach mcp --transport stdio
 ```
 
 ## Keeping gh-attach up to date
 
 ```bash
 # npm install
-npm install -g @addono/gh-attach@latest --registry=https://npm.pkg.github.com
+npm install -g gh-attach@latest
 
 # gh extension install
 gh extension upgrade Addono/gh-attach
@@ -72,7 +79,7 @@ gh extension upgrade Addono/gh-attach
 If you run via `npx`, there is nothing to upgrade locally — each invocation resolves the published package. Pin a version explicitly if you do not want the latest release:
 
 ```bash
-npx --registry=https://npm.pkg.github.com @addono/gh-attach@<version> mcp --transport stdio
+npx gh-attach@<version> mcp --transport stdio
 ```
 
 If you installed a standalone release binary, download the newest matching asset from the latest GitHub release and replace your existing `gh-attach` executable.
@@ -124,12 +131,12 @@ Commits images to an orphan branch. Works with any token.
 
 Choose the MCP command that matches how you installed `gh-attach`:
 
-| Install method            | MCP command                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| Standalone npm install    | `gh-attach mcp --transport stdio`                                                   |
-| Standalone release binary | `gh-attach mcp --transport stdio`                                                   |
-| `gh` extension            | `gh attach mcp --transport stdio`                                                   |
-| `npx`                     | `npx --registry=https://npm.pkg.github.com @addono/gh-attach mcp --transport stdio` |
+| Install method            | MCP command                           |
+| ------------------------- | ------------------------------------- |
+| Standalone npm install    | `gh-attach mcp --transport stdio`     |
+| Standalone release binary | `gh-attach mcp --transport stdio`     |
+| `gh` extension            | `gh attach mcp --transport stdio`     |
+| `npx`                     | `npx gh-attach mcp --transport stdio` |
 
 When the MCP client supports elicitation, `upload_image` can prompt for a GitHub token during the same tool call and continue the upload without requiring a separate `login` step first.
 
@@ -222,7 +229,7 @@ Add to `.vscode/settings.json`:
 
 This wrapper requires `bash` and an authenticated GitHub CLI session (`gh auth login`). It resolves the token at startup instead of storing it in the config file, but the token is still present in the MCP server process environment while it is running. If `bash` is unavailable, use the standalone CLI setup instead.
 
-If you prefer `npx`, use `command: "npx"` and prepend `--registry=https://npm.pkg.github.com`, `@addono/gh-attach` to the `args` array.
+If you prefer `npx`, use `command: "npx"` and prepend `gh-attach` to the `args` array.
 
 ## Configuration
 
@@ -279,6 +286,18 @@ npm run test:e2e    # E2E tests (requires secrets)
 npm run typecheck   # TypeScript strict mode
 npm run lint        # ESLint
 ```
+
+### Release automation
+
+- Public npm releases publish the unscoped package as `gh-attach`.
+- GitHub Packages keeps a scoped mirror at `@addono/gh-attach`.
+- GitHub Actions publishes to npm via Trusted Publishing (OIDC), so the release workflow does not need an `NPM_TOKEN` repository secret.
+- Configure npm trusted publishing for package `gh-attach` with:
+  - **Organization or user:** `Addono`
+  - **Repository:** `gh-attach`
+  - **Workflow filename:** `release.yml`
+  - **Environment name:** leave empty unless you later protect releases with a GitHub Actions environment
+- After the first trusted publish succeeds, npm recommends enabling **Require two-factor authentication and disallow tokens** in the package publishing access settings.
 
 ### Branch Protection (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ GitHub doesn't provide an official API for attaching images to issues and pull r
 
 ## Install
 
+For most users, install from the public npm registry — no npm authentication is required.
+
 ### Standalone CLI (npm)
 
 ```bash
@@ -30,10 +32,10 @@ npm install -g gh-attach
 
 Run it as `gh-attach ...`.
 
-### GitHub Packages mirror
+### Optional: GitHub Packages mirror
 
 ```bash
-# Install the scoped mirror from GitHub Packages
+# Install the scoped mirror from GitHub Packages (requires GitHub Packages auth)
 npm install -g @addono/gh-attach --registry=https://npm.pkg.github.com
 ```
 

--- a/openspec/specs/ci-cd/spec.md
+++ b/openspec/specs/ci-cd/spec.md
@@ -138,6 +138,19 @@ The system SHALL publish release artifacts.
 - WHEN the release workflow completes
 - THEN it SHALL publish the package to npm as `gh-attach`
 
+#### Scenario: GitHub Packages mirror publish
+
+- GIVEN a new version is released
+- WHEN the release workflow completes
+- THEN it SHALL publish a mirror package to GitHub Packages as `@addono/gh-attach`
+
+#### Scenario: release credentials
+
+- GIVEN the release workflow
+- WHEN it publishes packages
+- THEN it SHALL use GitHub Actions trusted publishing with OIDC for public npm
+- AND it SHALL use the workflow `GITHUB_TOKEN` with `packages: write` for GitHub Packages
+
 #### Scenario: GitHub Release
 
 - GIVEN a new version is released

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@addono/gh-attach",
+  "name": "gh-attach",
   "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@addono/gh-attach",
+      "name": "gh-attach",
       "version": "1.5.7",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@addono/gh-attach",
+  "name": "gh-attach",
   "version": "1.5.7",
   "description": "CLI tool and MCP server for attaching images to GitHub issues, PRs, and comments",
   "type": "module",
@@ -41,6 +41,8 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --project unit --project integration",
     "package": "node scripts/package-binaries.mjs",
+    "prepare:github-package": "node scripts/prepare-github-package.mjs",
+    "publish:github-package": "node scripts/publish-github-package.mjs",
     "prepare": "npm run build"
   },
   "pkg": {
@@ -69,10 +71,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Addono/gh-attach.git"
+    "url": "git+https://github.com/Addono/gh-attach.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/prepare-github-package.mjs
+++ b/scripts/prepare-github-package.mjs
@@ -1,0 +1,54 @@
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outputDir = resolve(rootDir, ".release", "github-package");
+const pkgPath = resolve(rootDir, "package.json");
+const version = process.env.GH_ATTACH_RELEASE_VERSION;
+
+if (!version) {
+  throw new Error("GH_ATTACH_RELEASE_VERSION is required.");
+}
+
+const sourcePackage = JSON.parse(readFileSync(pkgPath, "utf8"));
+const mirrorPackage = {
+  name: "@addono/gh-attach",
+  version,
+  description: sourcePackage.description,
+  type: sourcePackage.type,
+  main: sourcePackage.main,
+  types: sourcePackage.types,
+  bin: sourcePackage.bin,
+  exports: sourcePackage.exports,
+  files: sourcePackage.files,
+  keywords: sourcePackage.keywords,
+  author: sourcePackage.author,
+  license: sourcePackage.license,
+  repository: sourcePackage.repository,
+  publishConfig: {
+    registry: "https://npm.pkg.github.com",
+  },
+  engines: sourcePackage.engines,
+  dependencies: sourcePackage.dependencies,
+};
+
+rmSync(outputDir, { recursive: true, force: true });
+mkdirSync(outputDir, { recursive: true });
+
+for (const entry of mirrorPackage.files) {
+  cpSync(resolve(rootDir, entry), resolve(outputDir, entry), {
+    recursive: true,
+  });
+}
+
+writeFileSync(
+  resolve(outputDir, "package.json"),
+  `${JSON.stringify(mirrorPackage, null, 2)}\n`,
+);

--- a/scripts/publish-github-package.mjs
+++ b/scripts/publish-github-package.mjs
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packageDir = resolve(rootDir, ".release", "github-package");
+const npmrcPath = resolve(packageDir, ".npmrc");
+const token = process.env.GITHUB_PACKAGES_TOKEN;
+const npmPath = process.platform === "win32" ? "npm.cmd" : "npm";
+
+if (!existsSync(packageDir)) {
+  throw new Error("GitHub Packages mirror has not been prepared.");
+}
+
+if (!token) {
+  throw new Error("GITHUB_PACKAGES_TOKEN is required.");
+}
+
+writeFileSync(
+  npmrcPath,
+  [
+    "@addono:registry=https://npm.pkg.github.com",
+    `//npm.pkg.github.com/:_authToken=${token}`,
+    "",
+  ].join("\n"),
+);
+
+try {
+  const result = spawnSync(
+    npmPath,
+    ["publish", "--registry", "https://npm.pkg.github.com"],
+    {
+      cwd: packageDir,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        NPM_CONFIG_USERCONFIG: npmrcPath,
+      },
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+} finally {
+  rmSync(npmrcPath, { force: true });
+}


### PR DESCRIPTION
## Summary
- publish gh-attach publicly on npm and keep the GitHub Packages mirror
- switch the release workflow from NPM_TOKEN to npm Trusted Publishing via OIDC
- update release docs/specs for the bootstrap publish and trusted publisher setup

## Validation
- npm run format:check
- npm run lint
- npm run typecheck
- npm test
- npm run build