### PR TITLE
fix: resolve release version without npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci
       - id: resolve
         run: |
-          OUTPUT="$(npx semantic-release --dry-run --no-ci 2>&1 | tee /dev/stderr)"
+          OUTPUT="$(npx semantic-release --dry-run --no-ci --plugins @semantic-release/commit-analyzer @semantic-release/release-notes-generator 2>&1 | tee /dev/stderr)"
           VERSION="$(printf '%s\n' "$OUTPUT" | sed -nE 's/.*The next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | tail -n 1)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Summary
- fix the release workflow next-version dry-run so it no longer depends on npm token auth
- keep the actual publish job on npm Trusted Publishing via OIDC
- unblock end-to-end verification of automated npm publishing from GitHub Actions

## Validation
- npm run format:check
- npm run lint
- npm run typecheck
- npm test
- npm run build