### PR TITLE
fix: match npm registry URL for OIDC publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "url": "git+https://github.com/Addono/gh-attach.git"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org/"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- fix the public npm registry URL to exactly match the official registry constant used by @semantic-release/npm
- allow semantic-release to detect GitHub Actions Trusted Publishing instead of falling back to token auth
- unblock the automated npm publish path on main

## Validation
- npm run format:check
- npm run lint
- npm run typecheck
- npm test
- npm run build