### PR TITLE
feat: add video file support (mp4, mov, webm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 [![CI](https://github.com/Addono/gh-attach/actions/workflows/ci.yml/badge.svg)](https://github.com/Addono/gh-attach/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/gh-attach)](https://www.npmjs.com/package/gh-attach)
 
-> Upload images to GitHub issues, PRs, and comments — from the CLI or via MCP.
+> Upload images and videos to GitHub issues, PRs, and comments — from the CLI or via MCP.
 
 <p align="center">
   <img src="demo.svg" alt="gh-attach CLI demo" width="700">
 </p>
 
-GitHub doesn't provide an official API for attaching images to issues and pull requests. `gh-attach` fills this gap with multiple upload strategies, a clean CLI, and an MCP server for AI-powered workflows.
+GitHub doesn't provide an official API for comment attachments on issues and pull requests. `gh-attach` fills this gap with multiple upload strategies, a clean CLI, and an MCP server for AI-powered workflows.
 
 ## Features
 
 - **Multiple upload strategies** — browser session, cookie extraction, release assets (official API), repo-branch fallback
+- **Images + videos** — PNG, GIF, JPEG, SVG, WebP, MP4, MOV, and WEBM
 - **CLI tool** — works standalone or as a `gh` extension (`gh attach`)
 - **MCP server** — expose upload capabilities to AI applications via Model Context Protocol
 - **Fully tested** — unit, integration, and E2E test suites
@@ -61,7 +62,7 @@ Run it as `gh-attach ...`.
 ## Run without installing (npx)
 
 ```bash
-# Upload an image
+# Upload a file
 npx gh-attach upload ./screenshot.png --target owner/repo#42
 
 # Start the MCP server
@@ -93,7 +94,7 @@ Verify the active version with `gh-attach --version` or `gh attach --version`, d
 If you installed `gh-attach` as a GitHub CLI extension, replace `gh-attach` with `gh attach` in the examples below.
 
 ```bash
-# Upload an image to an issue
+# Upload a file to an issue
 gh-attach upload ./screenshot.png --target owner/repo#42
 
 # Upload using the release-asset strategy (official API, works with tokens)
@@ -105,6 +106,8 @@ gh-attach upload ./img.png --target #42 --format url
 # JSON output
 gh-attach upload ./img.png --target #42 --format json
 ```
+
+Videos (`.mp4`, `.mov`, `.webm`) are emitted as bare URLs in `markdown` output so GitHub can render them inline when the target upload URL supports video playback.
 
 ## Authentication
 
@@ -135,7 +138,7 @@ Automatically extracts GitHub cookies from Chrome/Firefox.
 
 ### Strategy 4: Repository Branch
 
-Commits images to an orphan branch. Works with any token.
+Commits attachments to an orphan branch. Works with any token.
 
 ## MCP Server
 

--- a/src/cli/commands/upload.ts
+++ b/src/cli/commands/upload.ts
@@ -271,7 +271,7 @@ export async function uploadCommand(files: string[], options: UploadOptions) {
 }
 
 /**
- * Reads image data from stdin.
+ * Reads file data from stdin.
  */
 async function readStdin(): Promise<Buffer> {
   return new Promise((resolve, reject) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -81,7 +81,7 @@ export function createProgram(): Command {
 
   program
     .name("gh-attach")
-    .description("Upload images to GitHub issues, PRs, and comments")
+    .description("Upload images and videos to GitHub issues, PRs, and comments")
     .version(resolveVersion())
     .option("-v, --verbose", "Print debug information to stderr")
     .option(
@@ -98,8 +98,8 @@ export function createProgram(): Command {
 
   program
     .command("upload")
-    .description("Upload an image and get a markdown embed URL")
-    .argument("[files...]", "Image file(s) to upload")
+    .description("Upload an image or video and get GitHub-ready output")
+    .argument("[files...]", "Image or video file(s) to upload")
     .option(
       "--target <ref>",
       "GitHub issue/PR reference (owner/repo#N, #N, or URL)",

--- a/src/core/attachment.ts
+++ b/src/core/attachment.ts
@@ -1,0 +1,69 @@
+import { basename, extname } from "path";
+
+/**
+ * Supported still-image attachment formats.
+ */
+const IMAGE_FORMATS = ["png", "jpg", "jpeg", "gif", "svg", "webp"] as const;
+
+/**
+ * Supported video attachment formats.
+ */
+const VIDEO_FORMATS = ["mp4", "mov", "webm"] as const;
+
+/**
+ * Supported attachment formats for GitHub uploads.
+ */
+export const SUPPORTED_FORMATS = [...IMAGE_FORMATS, ...VIDEO_FORMATS] as const;
+
+const SUPPORTED_FORMAT_SET = new Set<string>(SUPPORTED_FORMATS);
+const VIDEO_FORMAT_SET = new Set<string>(VIDEO_FORMATS);
+
+/**
+ * Maximum file size accepted during local validation before upload strategies run.
+ */
+export const MAX_FILE_SIZE = 25 * 1024 * 1024;
+
+/**
+ * Maximum file size in megabytes.
+ */
+export const MAX_FILE_SIZE_MB = MAX_FILE_SIZE / (1024 * 1024);
+
+/**
+ * Resolve a lowercase extension from a path.
+ */
+export function getFileExtension(filePath: string): string | undefined {
+  const extension = extname(filePath).slice(1).toLowerCase();
+  return extension || undefined;
+}
+
+/**
+ * Check whether a file extension is supported for upload.
+ */
+export function isSupportedFormat(extension: string | undefined): boolean {
+  return extension !== undefined && SUPPORTED_FORMAT_SET.has(extension);
+}
+
+/**
+ * Check whether a path refers to a video attachment.
+ */
+export function isVideoAttachment(filePath: string): boolean {
+  const extension = getFileExtension(filePath);
+  return extension !== undefined && VIDEO_FORMAT_SET.has(extension);
+}
+
+/**
+ * Build GitHub-flavored markdown output for an uploaded attachment.
+ *
+ * Videos are returned as bare URLs because GitHub only renders inline players
+ * when the attachment URL is not wrapped in image syntax.
+ */
+export function formatAttachmentMarkdown(
+  filePath: string,
+  url: string,
+): string {
+  if (isVideoAttachment(filePath)) {
+    return url;
+  }
+
+  return `![${basename(filePath)}](${url})`;
+}

--- a/src/core/strategies/browserSession.ts
+++ b/src/core/strategies/browserSession.ts
@@ -1,5 +1,6 @@
 import { basename } from "path";
 import { readFileSync } from "fs";
+import { formatAttachmentMarkdown } from "../attachment.js";
 import { AuthenticationError, UploadError } from "../types.js";
 import type { UploadResult, UploadStrategy, UploadTarget } from "../types.js";
 
@@ -75,7 +76,7 @@ export function createBrowserSessionStrategy(
         );
 
         // Generate markdown
-        const markdown = `![${basename(filePath)}](${url})`;
+        const markdown = formatAttachmentMarkdown(filePath, url);
 
         return {
           url,

--- a/src/core/strategies/releaseAsset.ts
+++ b/src/core/strategies/releaseAsset.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import { readFileSync } from "fs";
 import { basename } from "path";
+import { formatAttachmentMarkdown } from "../attachment.js";
 import { AuthenticationError, UploadError } from "../types.js";
 import type { UploadResult, UploadStrategy, UploadTarget } from "../types.js";
 
@@ -49,7 +50,7 @@ function getRateLimitReset(err: unknown): number | undefined {
 
 /**
  * Release Asset upload strategy using GitHub's official REST API.
- * Uploads images as assets to a special draft release in the repository.
+ * Uploads attachments as assets to a special release in the repository.
  *
  * @param token GitHub API token with `contents:write` permission
  * @returns UploadStrategy implementation
@@ -89,7 +90,7 @@ export function createReleaseAssetStrategy(token: string): UploadStrategy {
         );
 
         // Generate markdown
-        const markdown = `![${filename}](${url})`;
+        const markdown = formatAttachmentMarkdown(filePath, url);
 
         return {
           url,
@@ -141,8 +142,8 @@ async function findOrCreateAssetsRelease(
           owner: target.owner,
           repo: target.repo,
           tag_name: ASSETS_TAG,
-          name: "gh-attach image assets",
-          body: "This is a dummy release used by [gh-attach](https://github.com/Addono/gh-attach) as storage for image assets attached to issues and pull requests.\n\n> [!WARNING]\n> Do not delete this release or its assets — doing so will break image embeds that reference them.",
+          name: "gh-attach attachments",
+          body: "This is a dummy release used by [gh-attach](https://github.com/Addono/gh-attach) as storage for attachment files linked from issues and pull requests.\n\n> [!WARNING]\n> Do not delete this release or its assets — doing so will break attachment links and embeds that reference them.",
           draft: false,
           prerelease: true,
         });

--- a/src/core/strategies/repoBranch.ts
+++ b/src/core/strategies/repoBranch.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import { readFileSync } from "fs";
 import { basename } from "path";
+import { formatAttachmentMarkdown } from "../attachment.js";
 import { AuthenticationError, UploadError } from "../types.js";
 import type { UploadResult, UploadStrategy, UploadTarget } from "../types.js";
 
@@ -8,7 +9,7 @@ const BRANCH_NAME = "gh-attach-assets";
 
 /**
  * Repository Branch upload strategy using GitHub's REST API.
- * Commits images to a dedicated orphan branch and returns raw.githubusercontent.com URLs.
+ * Commits attachments to a dedicated orphan branch and returns raw.githubusercontent.com URLs.
  *
  * @param token GitHub API token with `contents:write` permission
  * @returns UploadStrategy implementation
@@ -55,7 +56,7 @@ export function createRepoBranchStrategy(token: string): UploadStrategy {
           `${commitSha}/${filename}`;
 
         // Generate markdown
-        const markdown = `![${filename}](${url})`;
+        const markdown = formatAttachmentMarkdown(filePath, url);
 
         return {
           url,
@@ -111,7 +112,7 @@ async function ensureAssetsBranch(
         const { data: blob } = await octokit.rest.git.createBlob({
           owner: target.owner,
           repo: target.repo,
-          content: "# gh-attach assets",
+          content: "# gh-attach attachments",
           encoding: "utf-8",
         });
 
@@ -131,7 +132,7 @@ async function ensureAssetsBranch(
         const { data: commit } = await octokit.rest.git.createCommit({
           owner: target.owner,
           repo: target.repo,
-          message: "Initial commit for image assets",
+          message: "Initial commit for attachment assets",
           tree: tree.sha,
           parents: [],
         });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * Represents a target location for uploading an image (an issue or pull request).
+ * Represents a target location for uploading an attachment (an issue or pull request).
  */
 export interface UploadTarget {
   /** GitHub repository owner */
@@ -17,12 +17,12 @@ export interface UploadTarget {
 }
 
 /**
- * Result of a successful image upload.
+ * Result of a successful attachment upload.
  */
 export interface UploadResult {
-  /** Direct URL to the uploaded image */
+  /** Direct URL to the uploaded attachment */
   url: string;
-  /** Markdown markdown format: `![](url)` */
+  /** GitHub-ready markdown output: image embed syntax or a bare video URL */
   markdown: string;
   /** Name of the strategy used */
   strategy: string;
@@ -30,15 +30,15 @@ export interface UploadResult {
 
 /**
  * Abstract interface for upload strategies.
- * Implementations provide different mechanisms to upload images to GitHub.
+ * Implementations provide different mechanisms to upload attachments to GitHub.
  */
 export interface UploadStrategy {
   /** Unique identifier for this strategy (e.g., "release-asset", "browser-session") */
   name: string;
   /**
-   * Upload an image file to the specified target location.
+   * Upload a supported attachment to the specified target location.
    *
-   * @param filePath Absolute path to the image file to upload
+   * @param filePath Absolute path to the file to upload
    * @param target The target issue or pull request
    * @returns Upload result with URL and markdown
    * @throws {UploadError} If the upload fails
@@ -113,7 +113,7 @@ export class UploadError extends GhAttachError {
  *
  * Error codes include:
  * - `FILE_TOO_LARGE` — File exceeds size limit
- * - `UNSUPPORTED_FORMAT` — Image format is not supported
+ * - `UNSUPPORTED_FORMAT` — Attachment format is not supported
  * - `INVALID_TARGET` — Target format is malformed
  */
 export class ValidationError extends GhAttachError {

--- a/src/core/upload.ts
+++ b/src/core/upload.ts
@@ -6,13 +6,13 @@ import {
 } from "./types.js";
 
 /**
- * Upload an image using the first available strategy from the provided list.
+ * Upload a supported attachment using the first available strategy from the provided list.
  *
  * Tries each strategy in order and uses the first one that uploads successfully.
  * Falls back through the list when a strategy is unavailable or when an available
  * strategy fails with an authentication or upload error.
  *
- * @param filePath Absolute path to the image file to upload
+ * @param filePath Absolute path to the file to upload
  * @param target The target issue or pull request
  * @param strategies List of upload strategies to try, in priority order
  * @returns Upload result with URL and markdown

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,25 +1,12 @@
 import { promises as fs } from "fs";
+import {
+  MAX_FILE_SIZE,
+  MAX_FILE_SIZE_MB,
+  SUPPORTED_FORMATS,
+  getFileExtension,
+  isSupportedFormat,
+} from "./attachment.js";
 import { ValidationError } from "./types.js";
-
-/**
- * Supported image formats for GitHub uploads.
- */
-const SUPPORTED_FORMATS = new Set([
-  "png",
-  "jpg",
-  "jpeg",
-  "gif",
-  "svg",
-  "webp",
-  "mp4",
-  "mov",
-  "webm",
-]);
-
-/**
- * Maximum file size for GitHub uploads: 25MB (GitHub's limit for video).
- */
-const MAX_FILE_SIZE = 25 * 1024 * 1024;
 
 /**
  * Validates that a file exists, has a supported format, and is within size limits.
@@ -27,7 +14,7 @@ const MAX_FILE_SIZE = 25 * 1024 * 1024;
  * @param filePath Path to the file to validate
  * @throws ValidationError with code FILE_NOT_FOUND if file doesn't exist
  * @throws ValidationError with code UNSUPPORTED_FORMAT if format is not supported
- * @throws ValidationError with code FILE_TOO_LARGE if file exceeds 10MB
+ * @throws ValidationError with code FILE_TOO_LARGE if file exceeds the size limit
  */
 export async function validateFile(filePath: string): Promise<void> {
   // Check file exists
@@ -41,19 +28,19 @@ export async function validateFile(filePath: string): Promise<void> {
   }
 
   // Check format
-  const ext = filePath.split(".").pop()?.toLowerCase();
-  if (!ext || !SUPPORTED_FORMATS.has(ext)) {
+  const ext = getFileExtension(filePath);
+  if (!isSupportedFormat(ext)) {
     throw new ValidationError(
-      `Unsupported file format: ${ext || "(no extension)"}. Supported: ${Array.from(SUPPORTED_FORMATS).join(", ")}`,
+      `Unsupported file format: ${ext || "(no extension)"}. Supported: ${SUPPORTED_FORMATS.join(", ")}`,
       "UNSUPPORTED_FORMAT",
-      { filePath, format: ext, supported: Array.from(SUPPORTED_FORMATS) },
+      { filePath, format: ext, supported: [...SUPPORTED_FORMATS] },
     );
   }
 
   // Check size
   if (stats.size > MAX_FILE_SIZE) {
     throw new ValidationError(
-      `File too large: ${stats.size} bytes exceeds 10MB limit`,
+      `File too large: ${stats.size} bytes exceeds ${MAX_FILE_SIZE_MB}MB limit`,
       "FILE_TOO_LARGE",
       { filePath, size: stats.size, maxSize: MAX_FILE_SIZE },
     );

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -4,12 +4,22 @@ import { ValidationError } from "./types.js";
 /**
  * Supported image formats for GitHub uploads.
  */
-const SUPPORTED_FORMATS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp"]);
+const SUPPORTED_FORMATS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "mp4",
+  "mov",
+  "webm",
+]);
 
 /**
- * Maximum file size for GitHub images: 10MB.
+ * Maximum file size for GitHub uploads: 25MB (GitHub's limit for video).
  */
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 25 * 1024 * 1024;
 
 /**
  * Validates that a file exists, has a supported format, and is within size limits.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 /**
- * gh-attach — Core library for uploading images to GitHub.
+ * gh-attach — Core library for uploading attachments to GitHub.
  *
  * This module exports the main types, error classes, strategy factories, and
- * utility functions for uploading images to GitHub issues and pull requests.
+ * utility functions for uploading attachments to GitHub issues and pull requests.
  * It provides a strategy-based interface for multiple upload mechanisms.
  *
  * @example
@@ -17,7 +17,7 @@
  *   number: 42
  * }, [strategy]);
  *
- * console.log(result.markdown); // ![](https://...)
+ * console.log(result.markdown); // ![](https://...) or a bare video URL
  * ```
  *
  * @module gh-attach

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -250,14 +250,15 @@ function shouldRetryWithElicitedToken(
 const TOOLS = [
   {
     name: "upload_image",
-    description: "Upload an image to GitHub and get a markdown embed URL",
+    description:
+      "Upload an image or video to GitHub and get GitHub-ready output",
     inputSchema: {
       type: "object",
       properties: {
-        filePath: { type: "string", description: "Path to the image file" },
+        filePath: { type: "string", description: "Path to the file to upload" },
         content: {
           type: "string",
-          description: "Base64 encoded image content",
+          description: "Base64 encoded file content",
         },
         filename: {
           type: "string",
@@ -599,7 +600,7 @@ async function startHttpServer(
  * Create and start the MCP server.
  *
  * Initializes a Model Context Protocol server with the specified transport mechanism.
- * The server exposes tools for uploading images to GitHub and managing authentication.
+ * The server exposes tools for uploading attachments to GitHub and managing authentication.
  *
  * @param transport Transport type: "stdio" (for embedding in Claude/VSCode) or "http" (for network access)
  * @param port Optional port for HTTP transport (default: 3000)

--- a/test/integration/cli/__snapshots__/snapshot.test.ts.snap
+++ b/test/integration/cli/__snapshots__/snapshot.test.ts.snap
@@ -28,7 +28,7 @@ Options:
 exports[`CLI Help Output Snapshots > should match main help output 1`] = `
 "Usage: gh-attach [options] [command]
 
-Upload images to GitHub issues, PRs, and comments
+Upload images and videos to GitHub issues, PRs, and comments
 
 Options:
   -V, --version                  output the version number
@@ -39,7 +39,8 @@ Options:
   -h, --help                     display help for command
 
 Commands:
-  upload [options] [files...]    Upload an image and get a markdown embed URL
+  upload [options] [files...]    Upload an image or video and get GitHub-ready
+                                 output
   login [options]                Authenticate with GitHub via browser
   config [action] [key] [value]  Manage gh-attach configuration
   mcp [options]                  Start the MCP server
@@ -60,10 +61,10 @@ Options:
 exports[`CLI Help Output Snapshots > should match upload command help output 1`] = `
 "Usage: gh-attach upload [options] [files...]
 
-Upload an image and get a markdown embed URL
+Upload an image or video and get GitHub-ready output
 
 Arguments:
-  files              Image file(s) to upload
+  files              Image or video file(s) to upload
 
 Options:
   --target <ref>     GitHub issue/PR reference (owner/repo#N, #N, or URL)

--- a/test/unit/cli/commands/upload.test.ts
+++ b/test/unit/cli/commands/upload.test.ts
@@ -112,6 +112,19 @@ describe("uploadCommand unit tests", () => {
     );
   });
 
+  it("passes through bare video URLs for markdown output", async () => {
+    vi.mocked(validateFile).mockResolvedValue(undefined);
+    vi.mocked(upload).mockResolvedValue({
+      url: "https://example.com/video.mp4",
+      markdown: "https://example.com/video.mp4",
+      strategy: "browser-session",
+    });
+
+    await uploadCommand(["test.mp4"], { target: "owner/repo#1" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("https://example.com/video.mp4");
+  });
+
   it("outputs URL format when --format url", async () => {
     vi.mocked(validateFile).mockResolvedValue(undefined);
     vi.mocked(upload).mockResolvedValue({

--- a/test/unit/core/attachment.test.ts
+++ b/test/unit/core/attachment.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAttachmentMarkdown,
+  getFileExtension,
+  isSupportedFormat,
+  isVideoAttachment,
+} from "../../../src/core/attachment.js";
+
+describe("attachment helpers", () => {
+  it("extracts lowercase extensions", () => {
+    expect(getFileExtension("/tmp/clip.MP4")).toBe("mp4");
+  });
+
+  it("returns undefined when a file has no extension", () => {
+    expect(getFileExtension("/tmp/clip")).toBeUndefined();
+  });
+
+  it("recognizes supported image and video formats", () => {
+    expect(isSupportedFormat("png")).toBe(true);
+    expect(isSupportedFormat("mp4")).toBe(true);
+    expect(isSupportedFormat("txt")).toBe(false);
+  });
+
+  it("detects video attachments by extension", () => {
+    expect(isVideoAttachment("/tmp/clip.webm")).toBe(true);
+    expect(isVideoAttachment("/tmp/image.png")).toBe(false);
+  });
+
+  it("formats images as markdown embeds", () => {
+    expect(
+      formatAttachmentMarkdown(
+        "/tmp/image.png",
+        "https://example.com/image.png",
+      ),
+    ).toBe("![image.png](https://example.com/image.png)");
+  });
+
+  it("formats videos as bare URLs", () => {
+    expect(
+      formatAttachmentMarkdown("/tmp/demo.mp4", "https://example.com/demo.mp4"),
+    ).toBe("https://example.com/demo.mp4");
+  });
+});

--- a/test/unit/core/strategies/browserSession.test.ts
+++ b/test/unit/core/strategies/browserSession.test.ts
@@ -430,6 +430,46 @@ describe("Browser Session Strategy", () => {
       });
     });
 
+    it("returns bare URLs for uploaded videos", async () => {
+      const strategy = createBrowserSessionStrategy("test-cookie");
+      const mockFilePath = "/tmp/test.mp4";
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 12345 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            upload_url: "https://s3.example.com/upload",
+            form: { key: "videos/test.mp4", policy: "encoded-policy" },
+            token: "csrf-token-123",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            url: "https://user-images.githubusercontent.com/test.mp4",
+          }),
+        });
+
+      const result = await strategy.upload(mockFilePath, mockTarget);
+
+      expect(result).toEqual({
+        url: "https://user-images.githubusercontent.com/test.mp4",
+        markdown: "https://user-images.githubusercontent.com/test.mp4",
+        strategy: "browser-session",
+      });
+    });
+
     it("includes form fields in S3 upload", async () => {
       const strategy = createBrowserSessionStrategy("test-cookie");
       const mockFilePath = "/tmp/image.jpg";

--- a/test/unit/core/strategies/releaseAsset.test.ts
+++ b/test/unit/core/strategies/releaseAsset.test.ts
@@ -130,6 +130,39 @@ describe("Release Asset Strategy", () => {
       });
     });
 
+    it("returns bare URLs for uploaded videos", async () => {
+      const strategy = createReleaseAssetStrategy("valid-token");
+      const mockFilePath = "/tmp/test.mp4";
+
+      const mockRelease = {
+        id: 123,
+        tag_name: "_gh-attach-assets",
+        draft: false,
+        prerelease: true,
+      };
+
+      const mockAsset = {
+        name: "test.mp4",
+        browser_download_url: "https://github.com/releases/download/test.mp4",
+      };
+
+      mockOctokitInstance.rest.repos.getReleaseByTag.mockResolvedValue({
+        data: mockRelease,
+      });
+      mockOctokitInstance.rest.repos.listReleaseAssets.mockResolvedValue({
+        data: [],
+      });
+      mockOctokitInstance.rest.repos.uploadReleaseAsset.mockResolvedValue({
+        data: mockAsset,
+      });
+
+      const result = await strategy.upload(mockFilePath, mockTarget);
+
+      expect(result.url).toBe(mockAsset.browser_download_url);
+      expect(result.markdown).toBe(mockAsset.browser_download_url);
+      expect(result.strategy).toBe("release-asset");
+    });
+
     it("creates release on first upload", async () => {
       const strategy = createReleaseAssetStrategy("valid-token");
       const mockFilePath = "/tmp/test.png";
@@ -166,8 +199,8 @@ describe("Release Asset Strategy", () => {
           owner: mockTarget.owner,
           repo: mockTarget.repo,
           tag_name: "_gh-attach-assets",
-          name: "gh-attach image assets",
-          body: "This is a dummy release used by [gh-attach](https://github.com/Addono/gh-attach) as storage for image assets attached to issues and pull requests.\n\n> [!WARNING]\n> Do not delete this release or its assets — doing so will break image embeds that reference them.",
+          name: "gh-attach attachments",
+          body: "This is a dummy release used by [gh-attach](https://github.com/Addono/gh-attach) as storage for attachment files linked from issues and pull requests.\n\n> [!WARNING]\n> Do not delete this release or its assets — doing so will break attachment links and embeds that reference them.",
           draft: false,
           prerelease: true,
         },

--- a/test/unit/core/strategies/repoBranch.test.ts
+++ b/test/unit/core/strategies/repoBranch.test.ts
@@ -135,6 +135,49 @@ describe("Repository Branch Strategy", () => {
       expect(result.markdown).toContain("![test.png]");
     });
 
+    it("returns bare URLs for uploaded videos", async () => {
+      const strategy = createRepoBranchStrategy("valid-token");
+      const mockFilePath = "/tmp/test.mp4";
+
+      const mockBranch = {
+        commit: {
+          sha: "abc123",
+        },
+      };
+
+      const mockTree = {
+        sha: "tree-sha",
+      };
+
+      const mockCommit = {
+        sha: "commit-sha",
+      };
+
+      mockOctokitInstance.rest.repos.getBranch.mockResolvedValue({
+        data: mockBranch,
+      });
+      mockOctokitInstance.rest.git.createBlob.mockResolvedValue({
+        data: { sha: "blob-sha" },
+      });
+      mockOctokitInstance.rest.git.getTree.mockResolvedValue({
+        data: mockTree,
+      });
+      mockOctokitInstance.rest.git.createTree.mockResolvedValue({
+        data: mockTree,
+      });
+      mockOctokitInstance.rest.git.createCommit.mockResolvedValue({
+        data: mockCommit,
+      });
+      mockOctokitInstance.rest.git.updateRef.mockResolvedValue({});
+
+      const result = await strategy.upload(mockFilePath, mockTarget);
+
+      expect(result.strategy).toBe("repo-branch");
+      expect(result.url).toContain("commit-sha");
+      expect(result.url).toContain("test.mp4");
+      expect(result.markdown).toBe(result.url);
+    });
+
     it("creates branch on first upload", async () => {
       const strategy = createRepoBranchStrategy("valid-token");
       const mockFilePath = "/tmp/test.png";

--- a/test/unit/core/validation.test.ts
+++ b/test/unit/core/validation.test.ts
@@ -52,6 +52,24 @@ describe("validateFile", () => {
     await expect(validateFile(filePath)).resolves.toBeUndefined();
   });
 
+  it("accepts MP4 files", async () => {
+    const filePath = path.join(tempDir, "test.mp4");
+    await fs.writeFile(filePath, Buffer.alloc(1000));
+    await expect(validateFile(filePath)).resolves.toBeUndefined();
+  });
+
+  it("accepts MOV files", async () => {
+    const filePath = path.join(tempDir, "test.mov");
+    await fs.writeFile(filePath, Buffer.alloc(1000));
+    await expect(validateFile(filePath)).resolves.toBeUndefined();
+  });
+
+  it("accepts WEBM files", async () => {
+    const filePath = path.join(tempDir, "test.webm");
+    await fs.writeFile(filePath, Buffer.alloc(1000));
+    await expect(validateFile(filePath)).resolves.toBeUndefined();
+  });
+
   it("accepts uppercase extensions", async () => {
     const filePath = path.join(tempDir, "test.PNG");
     await fs.writeFile(filePath, Buffer.alloc(1000));
@@ -107,9 +125,9 @@ describe("validateFile", () => {
     }
   });
 
-  it("throws FILE_TOO_LARGE for files exceeding 10MB", async () => {
+  it("throws FILE_TOO_LARGE for files exceeding 25MB", async () => {
     const filePath = path.join(tempDir, "large.png");
-    const size = 11 * 1024 * 1024; // 11MB
+    const size = 26 * 1024 * 1024; // 26MB
     const file = await fs.open(filePath, "w");
     await file.write(Buffer.alloc(1024 * 1024), 0, 1024 * 1024, 0);
     await file.truncate(size);
@@ -122,14 +140,14 @@ describe("validateFile", () => {
       expect(err).toBeInstanceOf(ValidationError);
       expect((err as ValidationError).code).toBe("FILE_TOO_LARGE");
       expect((err as ValidationError).details?.size).toBeGreaterThan(
-        10 * 1024 * 1024,
+        25 * 1024 * 1024,
       );
     }
   });
 
-  it("accepts files at 10MB boundary", async () => {
+  it("accepts files at 25MB boundary", async () => {
     const filePath = path.join(tempDir, "boundary.png");
-    const size = 10 * 1024 * 1024;
+    const size = 25 * 1024 * 1024;
     const file = await fs.open(filePath, "w");
     await file.truncate(size);
     await file.close();
@@ -151,6 +169,7 @@ describe("validateFile", () => {
       >;
       expect(Array.isArray(details.supported)).toBe(true);
       expect((details.supported as string[]).includes("png")).toBe(true);
+      expect((details.supported as string[]).includes("mp4")).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Why

GitHub supports mp4, mov, and webm video uploads in PR and issue comments, but `gh-attach` only allows image formats. This prevents using `gh-attach` for uploading demo videos or screen recordings.

## What changed

**Before:**
- Supported formats: png, jpg, jpeg, gif, svg, webp
- Max file size: 10MB

**After:**
- Supported formats: png, jpg, jpeg, gif, svg, webp, mp4, mov, webm
- Max file size: 25MB (matches GitHub's own limit for video attachments)