### PR TITLE
fix: report active package version in MCP startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ Commits attachments to an orphan branch. Works with any token.
 
 Choose the MCP command that matches how you installed `gh-attach`:
 
-| Install method            | MCP command                           |
-| ------------------------- | ------------------------------------- |
-| Standalone npm install    | `gh-attach mcp --transport stdio`     |
-| Standalone release binary | `gh-attach mcp --transport stdio`     |
-| `gh` extension            | `gh attach mcp --transport stdio`     |
+| Install method            | MCP command                                     |
+| ------------------------- | ----------------------------------------------- |
+| Standalone npm install    | `gh-attach mcp --transport stdio`               |
+| Standalone release binary | `gh-attach mcp --transport stdio`               |
+| `gh` extension            | `gh attach mcp --transport stdio`               |
 | `npx`                     | `npx -y gh-attach@latest mcp --transport stdio` |
 
 When the MCP client supports elicitation, `upload_image` can prompt for a GitHub token during the same tool call and continue the upload without requiring a separate `login` step first.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,10 +12,8 @@ process.on("warning", (warning) => {
   process.stderr.write(`${warning.stack ?? warning.message}\n`);
 });
 
-import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
 import { Command } from "commander";
+import { resolvePackageVersion } from "../core/version.js";
 import {
   AuthenticationError,
   ValidationError,
@@ -49,25 +47,10 @@ export function getExitCode(err: unknown): number {
 }
 
 /**
- * Resolves the package version by reading the nearest `package.json`.
- *
- * Works in both source (`src/cli/`) and dist (`dist/`) layouts.
+ * Resolves the version for the currently running gh-attach CLI.
  */
 export function resolveVersion(): string {
-  // In pkg binary builds, version is injected at build time
-  if (process.env.__PKG_VERSION__) {
-    return process.env.__PKG_VERSION__;
-  }
-  const dir = dirname(fileURLToPath(import.meta.url));
-  const pkgPath = resolve(
-    dir,
-    dir.endsWith("/src/cli") ? "../.." : "..",
-    "package.json",
-  );
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
-    version: string;
-  };
-  return pkg.version;
+  return resolvePackageVersion(import.meta.url);
 }
 
 /**

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Fallback version used when package metadata cannot be resolved.
+ */
+export const DEVELOPMENT_VERSION = "0.0.0-development";
+
+const MAX_PACKAGE_SEARCH_DEPTH = 3;
+
+function readPackageVersion(pkgPath: string): string | undefined {
+  if (!existsSync(pkgPath)) {
+    return undefined;
+  }
+
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+    version?: unknown;
+  };
+
+  if (typeof pkg.version === "string" && pkg.version.length > 0) {
+    return pkg.version;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves the package version for the currently running module.
+ *
+ * Walks upward from the provided module URL so the same helper works from
+ * source files under `src/`, built files under `dist/`, and packaged npm
+ * installs used by `npx`.
+ */
+export function resolvePackageVersion(
+  moduleUrl: string,
+  fallback = DEVELOPMENT_VERSION,
+): string {
+  if (process.env.__PKG_VERSION__) {
+    return process.env.__PKG_VERSION__;
+  }
+
+  try {
+    let currentDir = dirname(fileURLToPath(moduleUrl));
+
+    for (let depth = 0; depth <= MAX_PACKAGE_SEARCH_DEPTH; depth += 1) {
+      const version = readPackageVersion(resolve(currentDir, "package.json"));
+      if (version) {
+        return version;
+      }
+
+      const parentDir = resolve(currentDir, "..");
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+  } catch {
+    // Fall through to the development version below.
+  }
+
+  return fallback;
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { randomUUID } from "crypto";
-import { writeFileSync, unlinkSync, readFileSync, existsSync } from "fs";
+import { writeFileSync, unlinkSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer } from "http";
@@ -42,21 +42,9 @@ import {
   type UploadStrategy,
   type UploadTarget,
 } from "../core/types.js";
+import { resolvePackageVersion } from "../core/version.js";
 
-// Get package version
-function getPackageVersion(): string {
-  try {
-    const pkgPath = new URL("../../package.json", import.meta.url).pathname;
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
-      version: string;
-    };
-    return pkg.version;
-  } catch {
-    return "0.0.0-development";
-  }
-}
-
-const VERSION = getPackageVersion();
+const VERSION = resolvePackageVersion(import.meta.url);
 const AUTH_GUIDANCE =
   "No authentication available. Set GITHUB_TOKEN (or GH_TOKEN), run 'gh-attach login' to save a session token, provide GH_ATTACH_COOKIES, or authenticate with the GitHub CLI. If multiple gh accounts are signed in, use 'gh auth status' to inspect them and 'gh auth token --user <login>' to verify the right identity.";
 

--- a/test/integration/cli/binary.test.ts
+++ b/test/integration/cli/binary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 
@@ -77,6 +77,22 @@ describe("ESM Bundle", () => {
     }).trim();
     const cjsVersion = runCjs("--version");
     expect(esmVersion).toBe(cjsVersion);
+  });
+
+  it("should report the active version when starting MCP over stdio", () => {
+    const result = spawnSync(
+      "node",
+      [ESM_PATH, "mcp", "--transport", "stdio"],
+      {
+        encoding: "utf8",
+        cwd: ROOT,
+        timeout: 1500,
+      },
+    );
+
+    expect(result.stderr).toContain(
+      `[gh-attach MCP] Server started (stdio mode, version ${EXPECTED_VERSION})`,
+    );
   });
 });
 

--- a/test/integration/mcp/http-transport.test.ts
+++ b/test/integration/mcp/http-transport.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { mcpInternals } from "../../../src/mcp/index.js";
+
+const ROOT = resolve(import.meta.dirname, "../../..");
+const EXPECTED_VERSION =
+  process.env.GH_ATTACH_BUILD_VERSION ??
+  JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8")).version;
 
 describe("MCP Streamable HTTP transport", () => {
   let baseUrl: URL;
@@ -25,8 +32,7 @@ describe("MCP Streamable HTTP transport", () => {
 
     const body = (await res.json()) as { status: string; version: string };
     expect(body.status).toBe("ok");
-    expect(typeof body.version).toBe("string");
-    expect(body.version.length).toBeGreaterThan(0);
+    expect(body.version).toBe(EXPECTED_VERSION);
   });
 
   it("supports initialize + tools/list + tools/call over Streamable HTTP", async () => {

--- a/test/unit/core/version.test.ts
+++ b/test/unit/core/version.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import {
+  DEVELOPMENT_VERSION,
+  resolvePackageVersion,
+} from "../../../src/core/version.js";
+
+describe("resolvePackageVersion", () => {
+  let tempRoot = "";
+
+  beforeEach(() => {
+    delete process.env.__PKG_VERSION__;
+
+    tempRoot = mkdtempSync(join(tmpdir(), "gh-attach-version-"));
+    writeFileSync(
+      join(tempRoot, "package.json"),
+      JSON.stringify({ version: "9.9.9" }),
+    );
+    mkdirSync(join(tempRoot, "src", "mcp"), { recursive: true });
+    mkdirSync(join(tempRoot, "dist"), { recursive: true });
+  });
+
+  afterEach(() => {
+    delete process.env.__PKG_VERSION__;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("resolves the package version from source layout paths", () => {
+    const version = resolvePackageVersion(
+      pathToFileURL(join(tempRoot, "src", "mcp", "index.ts")).href,
+    );
+
+    expect(version).toBe("9.9.9");
+  });
+
+  it("resolves the package version from dist layout paths", () => {
+    const version = resolvePackageVersion(
+      pathToFileURL(join(tempRoot, "dist", "mcp.js")).href,
+    );
+
+    expect(version).toBe("9.9.9");
+  });
+
+  it("prefers the injected build version when present", () => {
+    process.env.__PKG_VERSION__ = "2.3.4";
+
+    const version = resolvePackageVersion(
+      pathToFileURL(join(tempRoot, "dist", "mcp.js")).href,
+    );
+
+    expect(version).toBe("2.3.4");
+  });
+
+  it("falls back to the development version when package metadata is missing", () => {
+    const orphanRoot = mkdtempSync(
+      join(tmpdir(), "gh-attach-version-missing-"),
+    );
+    mkdirSync(join(orphanRoot, "dist"), { recursive: true });
+
+    try {
+      const version = resolvePackageVersion(
+        pathToFileURL(join(orphanRoot, "dist", "mcp.js")).href,
+      );
+
+      expect(version).toBe(DEVELOPMENT_VERSION);
+    } finally {
+      rmSync(orphanRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the MCP version from the running gh-attach package instead of falling back to `0.0.0-development`
- reuse the same package-version lookup across the CLI and MCP code paths
- add regression coverage for source layout, built layout, HTTP health, and the built CLI MCP startup log

## Expected behavior
`npx -y gh-attach@latest mcp` should report the version of the gh-attach package currently in use. With the current package metadata, that is `1.7.0`.

## Testing
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test
- packaged npx smoke test against `npm pack` output