### PR TITLE
fix: align CI with release build version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,23 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  release-parity:
+    name: Release parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+        env:
+          GH_ATTACH_BUILD_VERSION: 9.9.9
+      - run: npm test
+        env:
+          GH_ATTACH_BUILD_VERSION: 9.9.9
+
   test:
     name: Test (Node ${{ matrix.node }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -9,6 +9,17 @@ export const DEVELOPMENT_VERSION = "0.0.0-development";
 
 const MAX_PACKAGE_SEARCH_DEPTH = 3;
 
+function readInjectedBuildVersion(): string | undefined {
+  const version =
+    process.env.__PKG_VERSION__ ?? process.env.GH_ATTACH_BUILD_VERSION;
+
+  if (typeof version === "string" && version.length > 0) {
+    return version;
+  }
+
+  return undefined;
+}
+
 function readPackageVersion(pkgPath: string): string | undefined {
   if (!existsSync(pkgPath)) {
     return undefined;
@@ -36,8 +47,9 @@ export function resolvePackageVersion(
   moduleUrl: string,
   fallback = DEVELOPMENT_VERSION,
 ): string {
-  if (process.env.__PKG_VERSION__) {
-    return process.env.__PKG_VERSION__;
+  const injectedBuildVersion = readInjectedBuildVersion();
+  if (injectedBuildVersion) {
+    return injectedBuildVersion;
   }
 
   try {

--- a/test/unit/core/version.test.ts
+++ b/test/unit/core/version.test.ts
@@ -13,6 +13,7 @@ describe("resolvePackageVersion", () => {
 
   beforeEach(() => {
     delete process.env.__PKG_VERSION__;
+    delete process.env.GH_ATTACH_BUILD_VERSION;
 
     tempRoot = mkdtempSync(join(tmpdir(), "gh-attach-version-"));
     writeFileSync(
@@ -25,6 +26,7 @@ describe("resolvePackageVersion", () => {
 
   afterEach(() => {
     delete process.env.__PKG_VERSION__;
+    delete process.env.GH_ATTACH_BUILD_VERSION;
     rmSync(tempRoot, { recursive: true, force: true });
   });
 
@@ -46,6 +48,27 @@ describe("resolvePackageVersion", () => {
 
   it("prefers the injected build version when present", () => {
     process.env.__PKG_VERSION__ = "2.3.4";
+
+    const version = resolvePackageVersion(
+      pathToFileURL(join(tempRoot, "dist", "mcp.js")).href,
+    );
+
+    expect(version).toBe("2.3.4");
+  });
+
+  it("uses the release build version during source-driven runs", () => {
+    process.env.GH_ATTACH_BUILD_VERSION = "3.4.5";
+
+    const version = resolvePackageVersion(
+      pathToFileURL(join(tempRoot, "src", "mcp", "index.ts")).href,
+    );
+
+    expect(version).toBe("3.4.5");
+  });
+
+  it("prefers the bundled build version over the runtime release override", () => {
+    process.env.__PKG_VERSION__ = "2.3.4";
+    process.env.GH_ATTACH_BUILD_VERSION = "3.4.5";
 
     const version = resolvePackageVersion(
       pathToFileURL(join(tempRoot, "dist", "mcp.js")).href,


### PR DESCRIPTION
## Summary
- honor release build version injection during source-driven version resolution
- add release-parity coverage to CI so pull requests exercise the release-versioned build/test path
- close the gap that let the release validation failure slip through PR CI

## Testing
- npm run lint
- npm run format:check
- npm run typecheck
- npm test
- npm run build
- GH_ATTACH_BUILD_VERSION=9.9.9 npm run build
- GH_ATTACH_BUILD_VERSION=9.9.9 npm test